### PR TITLE
chore: v1.0.1 enhancements — dep updates and nightly lint fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-compression"

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,7 @@
     all(feature = "unstable", nightly),
     deny(
         deprecated_llvm_intrinsic,
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,


### PR DESCRIPTION
## Summary

- Bump dependency versions (e.g. `anyhow` 1.0.102 → 1.0.103) and update `Cargo.lock`
- Replace the deprecated `fuzzy_provenance_casts` + `lossy_provenance_casts` nightly lints with the unified `implicit_provenance_casts` lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)